### PR TITLE
Do not log memcap warnings

### DIFF
--- a/main.go
+++ b/main.go
@@ -836,7 +836,13 @@ func produceMetrics(ch chan<- prometheus.Metric, counters map[string]any) {
 				log.Printf("WARN: Unhandled thread: %s", threadName)
 			}
 		} else {
-			log.Printf("WARN: Threads entry %s not a map[string]", threadName)
+			// The following two show up under threads in 7.0.x,
+			// ignore them.
+			//
+			// https://redmine.openinfosecfoundation.org/issues/6398
+			if threadName != "memcap_pressure" && threadName != "memcap_pressure_max" {
+				log.Printf("WARN: Threads entry %s not a map[string]", threadName)
+			}
 		}
 	}
 


### PR DESCRIPTION
The issue is fixed in Suricata 8.0.x, but 7.0.x won't get a backport, so lets just start ignoring these two specifically.

Closes #15